### PR TITLE
Optimize lcv a little (but not enough)

### DIFF
--- a/CS3243_P2_Sudoku_15.py
+++ b/CS3243_P2_Sudoku_15.py
@@ -61,9 +61,11 @@ class Sudoku(object):
             self.puzzle = puzzle
             return True
 
-        ordered_domain_values = self.get_ordered_domain_values((mrv_row, mrv_col), puzzle)
+        mrv_values = puzzle[mrv_row][mrv_col].copy()
+        #ordered_domain_values = self.get_ordered_domain_values((mrv_row, mrv_col), puzzle)
 
-        for value in ordered_domain_values:
+        #for value, frequency in ordered_domain_values:
+        for value in mrv_values:
             current_puzzle = copy.deepcopy(puzzle)
             current_puzzle[mrv_row][mrv_col] = set()
             current_puzzle[mrv_row][mrv_col].add(value)
@@ -115,7 +117,7 @@ class Sudoku(object):
                     num_of_removed_values += 1
             ordered_value_tuples.append((value, num_of_removed_values))
         ordered_value_tuples.sort(key = lambda tup: tup[1])
-        return map(lambda x: x[0], ordered_value_tuples)
+        return ordered_value_tuples
 
     # Helper function to return positions of the connecting cells that have not been assigned a value yet.
     def get_empty_connecting_cell_positions(self, puzzle, position):


### PR DESCRIPTION
Optimized the code just a little bit.
Changed the code back to picking of domain values in increasing order since that is significantly faster than the lcv. 
Can check for the ordered domain values by uncommenting the lines that declare and use the variables 'ordered_domain_values.'